### PR TITLE
fixed an include bug (std::strcpy is part of <cstdio>)

### DIFF
--- a/imfilebrowser.h
+++ b/imfilebrowser.h
@@ -4,7 +4,7 @@
 #include <filesystem>
 #include <functional>
 #include <memory>
-#include <string>
+#include <cstring>
 
 #ifndef IMGUI_VERSION
 #   error "include imgui.h before this header"


### PR DESCRIPTION
I had an issue with compiling under Ubuntu and got the compiler error, that " ‘strcpy’ is not a member of ‘std’ ". Changing the include directive to cstring fixes this problem for me.

This is tested under Ubuntu 18.04 with gcc-9.0.1 and clang 9.0.1