### PR TITLE
added precompiler if-clause to eliminate function call under ubuntu

### DIFF
--- a/imfilebrowser.h
+++ b/imfilebrowser.h
@@ -190,7 +190,9 @@ inline void ImGui::FileBrowser::Open()
     statusStr_ = std::string();
     openFlag_ = true;
     closeFlag_ = false;
+#ifdef _WIN32
     GetDrivesBitMask();
+#endif
 }
 
 inline void ImGui::FileBrowser::Close()


### PR DESCRIPTION
I had an issue with compiling under Ubuntu and got the compiler error, that "  ‘GetDrivesBitMask’ was not declared in this scope ". After seeing that this function is only created when working with windows, I added a precompiler-if to one of the function calls.

This is tested under Ubuntu 18.04 with gcc-9.0.1 and clang 9.0.1