### PR TITLE
Update imfilebrowser.h

### DIFF
--- a/imfilebrowser.h
+++ b/imfilebrowser.h
@@ -609,7 +609,7 @@ inline void ImGui::FileBrowser::SetPwdUncatched(const std::filesystem::path &pwd
 
 #endif // #ifndef WIN32_LEAN_AND_MEAN
 
-#include <Windows.h>
+#include <windows.h>
 
 #ifdef IMGUI_FILEBROWSER_UNDEF_WIN32_LEAN_AND_MEAN
 #undef IMGUI_FILEBROWSER_UNDEF_WIN32_LEAN_AND_MEAN


### PR DESCRIPTION
fix "include <windows.h>" since header file names are case-sensitive on Linux to allow cross-compile from Linux to Windows.