### PR TITLE
replace std::function based scope guard by templated version.

### DIFF
--- a/imfilebrowser.h
+++ b/imfilebrowser.h
@@ -115,7 +115,7 @@ namespace ImGui
         template <class Functor>
         struct ScopeGuard
         {
-            ScopeGuard(Functor&& t) : func(std::move(t)) {};
+            ScopeGuard(Functor&& t) : func(std::move(t)) { }
 
             ~ScopeGuard()
             {

--- a/imfilebrowser.h
+++ b/imfilebrowser.h
@@ -29,7 +29,6 @@ SOFTWARE.
 #include <array>
 #include <cstring>
 #include <filesystem>
-#include <functional>
 #include <memory>
 #include <set>
 #include <string>
@@ -113,16 +112,20 @@ namespace ImGui
 
     private:
 
-        class ScopeGuard
-        {
-            std::function<void()> func_;
+		template <class Functor>
+		struct ScopeGuard
+		{
+			ScopeGuard(Functor&& t) : func(std::move(t)) {};
 
-        public:
+			~ScopeGuard()
+			{
+				func();
+			}
 
-            template<typename T>
-            explicit ScopeGuard(T func) : func_(std::move(func)) { }
-            ~ScopeGuard() { func_(); }
-        };
+		private:
+
+			Functor func;
+		};
 
         void SetPwdUncatched(const std::filesystem::path &pwd);
 

--- a/imfilebrowser.h
+++ b/imfilebrowser.h
@@ -111,21 +111,21 @@ namespace ImGui
         void SetTypeFilters(const std::vector<const char*> &typeFilters);
 
     private:
+    
+        template <class Functor>
+        struct ScopeGuard
+        {
+            ScopeGuard(Functor&& t) : func(std::move(t)) {};
 
-		template <class Functor>
-		struct ScopeGuard
-		{
-			ScopeGuard(Functor&& t) : func(std::move(t)) {};
+            ~ScopeGuard()
+            {
+                func();
+            }
 
-			~ScopeGuard()
-			{
-				func();
-			}
+        private:
 
-		private:
-
-			Functor func;
-		};
+            Functor func;
+        };
 
         void SetPwdUncatched(const std::filesystem::path &pwd);
 


### PR DESCRIPTION
std::function can involve runtime and memory overhead and its specificities are not necessary in this use case, also removing the <functional> header improve compilation time.