### PR TITLE
 Fix GCC -Werror=sign-conversion

### DIFF
--- a/imfilebrowser.h
+++ b/imfilebrowser.h
@@ -151,7 +151,7 @@ namespace ImGui
         std::string statusStr_;
 
         std::vector<std::string> typeFilters_;
-        int typeFilterIndex_;
+        unsigned int typeFilterIndex_;
         bool hasAllFilter_;
 
         std::filesystem::path pwd_;
@@ -637,10 +637,10 @@ inline void ImGui::FileBrowser::Display()
 
             for(size_t i = 0; i < typeFilters_.size(); ++i)
             {
-                bool selected = static_cast<int>(i) == typeFilterIndex_;
+                bool selected = i == typeFilterIndex_;
                 if(Selectable(typeFilters_[i].c_str(), selected) && !selected)
                 {
-                    typeFilterIndex_ = static_cast<int>(i);
+                    typeFilterIndex_ = static_cast<unsigned int>(i);
                 }
             }
         }
@@ -776,7 +776,7 @@ inline void ImGui::FileBrowser::SetTypeFilters(
 
 inline void ImGui::FileBrowser::SetCurrentTypeFilterIndex(int index)
 {
-    typeFilterIndex_ = index;
+    typeFilterIndex_ = static_cast<unsigned int>(index);
 }
 
 inline void ImGui::FileBrowser::SetInputName(std::string_view input)


### PR DESCRIPTION
All these changes are related to this warning.
-Werror=sign-conversion

- cast index in SetCurrentTypeFilterIndex to unsigned int.
- static_cast<int> to static_cast<unsigned int> though we probably don't need the cast if both are unsigned. Should be safe for at least the compare line.
- make typeFilterIndex_ unsigned.

I went to compile my code on GCC and had warnings enabled with warnings as errors.

I tried to change as few lines a possible to get the code to compile.