### PR TITLE
Adapting to ImGui's new IO event API (1.87)

### DIFF
--- a/imfilebrowser.h
+++ b/imfilebrowser.h
@@ -609,12 +609,11 @@ inline void ImGui::FileBrowser::Display()
 
     SameLine();
 
-    int escapeKey = GetIO().KeyMap[ImGuiKey_Escape];
     bool shouldExit =
         Button("cancel") || closeFlag_ ||
         ((flags_ & ImGuiFileBrowserFlags_CloseOnEsc) &&
         IsWindowFocused(ImGuiFocusedFlags_RootAndChildWindows) &&
-        escapeKey >= 0 && IsKeyPressed(escapeKey));
+        IsKeyPressed(ImGuiKey_Escape));
     if(shouldExit)
     {
         CloseCurrentPopup();


### PR DESCRIPTION
There is a new IO keyboard/mouse/gamepad event API (1.87) recap in ImGui: https://github.com/ocornut/imgui/issues/4921
The transition guide describes, among others, that `GetIO().KeyMap` shall no longer be used. It is now deprecated functionality.

If deprecated functionality is removed from ImGui through
```
#define IMGUI_DISABLE_OBSOLETE_KEYIO
```
code that uses ``GetIO().KeyMap` not even compiles anymore, which affects imgui-filebrowser.

This PR proposes to use `IsKeyPressed(ImGuiKey_Escape)` instead of `GetIO().KeyMap[ImGuiKey_Escape]` and `IsKeyPressed(escapeKey)`.