### PR TITLE
Reset hasAllFilter_ when changing type filters

### DIFF
--- a/imfilebrowser.h
+++ b/imfilebrowser.h
@@ -771,7 +771,7 @@ inline void ImGui::FileBrowser::SetTypeFilters(
 #endif
 
     // insert auto-generated filter
-
+    hasAllFilter_ = false;
     if(typeFilters.size() > 1)
     {
         hasAllFilter_  = true;


### PR DESCRIPTION
Imagine the following steps:
- On a new browser, set the type filters to a list of 2 or more items, without an item that is `.*`.
- Then, set the filters to a list of a single file type.

During the first step, the internal `hasAllFilter_` flag will be set to true, as the browser generates the filter option that contains all file types at once.

During the second step, that flag does not get reset to false, even though it should be, since no additional "all types" filter gets generated when there's only a single file type in the list.

In this state, files will not properly show up in the file browser, because `IsExtensionMatched` will try to match any file extension against the list of types starting at index 1. Since there's only one type in the list, this will always fail, so all files fail the extension check and are hidden.

This commit just resets the `hasAllFilter_` flag whenever types are set, before it is potentially set back to true if the new list of types is in fact longer than a single element.