### PR TITLE
Remove "and the 'ok' button was clicked" to `HasSelected()` description

### DIFF
--- a/imfilebrowser.h
+++ b/imfilebrowser.h
@@ -67,7 +67,7 @@ namespace ImGui
         // display the browsing window if opened
         void Display();
 
-        // returns true when there is a selected filename and the "ok" button was clicked
+        // returns true when there is a selected filename
         bool HasSelected() const noexcept;
 
         // set current browsing directory


### PR DESCRIPTION
I would say it creates some confusion, as it states that it returns `true` when the "ok" button is clicked implying that it will return `true` for one frame.

This doesn't necessary happen when the "ok" button is clicked either, you can double-click on a file/directory and get `HasSelected()` to return `true` anyway.