### PR TITLE
Fix type of ImGuiFileBrowserFlags to match the enum

### DIFF
--- a/imfilebrowser.h
+++ b/imfilebrowser.h
@@ -14,7 +14,7 @@
 #   error "include imgui.h before this header"
 #endif
 
-using ImGuiFileBrowserFlags = int;
+using ImGuiFileBrowserFlags = std::uint32_t;
 
 enum ImGuiFileBrowserFlags_ : std::uint32_t
 {


### PR DESCRIPTION
I was getting this warning in GCC and an Error because one type was int and one was unsigned int. So it was doing a sign-conversion.

Conversion to ‘unsigned int’ from ‘ImGuiFileBrowserFlags’ {aka ‘int’} may change the sign of the result [-Werror=sign-conversion]

<details><summary>Logs</summary>

```c++
CMake Error: Unknown argument --build
CMake Error: Run 'cmake --help' for all supported options.
(venv) root@DESKTOP-PO4DJP8:/mnt/d/dev/Field-Map-Editor# cmake --build ./linux/build
Error: could not load cache
(venv) root@DESKTOP-PO4DJP8:/mnt/d/dev/Field-Map-Editor# cd ./linux/build
(venv) root@DESKTOP-PO4DJP8:/mnt/d/dev/Field-Map-Editor/linux/build# ls
RelWithDebInfo
(venv) root@DESKTOP-PO4DJP8:/mnt/d/dev/Field-Map-Editor/linux/build# cd relwithdebinfo
(venv) root@DESKTOP-PO4DJP8:/mnt/d/dev/Field-Map-Editor/linux/build/relwithdebinfo# ls
CMakeCache.txt  CMakeFiles  Makefile  _deps  cmake_install.cmake  compile_commands.json  generators  src
(venv) root@DESKTOP-PO4DJP8:/mnt/d/dev/Field-Map-Editor/linux/build/relwithdebinfo# make
[  0%] Built target IconFontCppHeaders
[  0%] Built target OpenVIII_CPP_WIP_VIIIArchive
[  1%] Building CXX object src/sfml/CMakeFiles/ImGui-SFML.dir/__/__/_deps/imgui-sfml_fetch-src/imgui-SFML.cpp.o
[  2%] Linking CXX static library libImGui-SFML.a
[  2%] Built target ImGui-SFML
[  3%] Building C object _deps/openviii_cpp_wip_fetch-build/CMakeFiles/OpenVIII_CPP_WIP_External_lz4.dir/__/lz4_lib-src/lib/lz4.c.o
[  4%] Linking CXX static library libOpenVIII_CPP_WIP_External_lz4.a
[  4%] Built target OpenVIII_CPP_WIP_External_lz4
[  5%] Building CXX object src/sfml/CMakeFiles/Field-Map-Editor_SFML.dir/test.cpp.o
In file included from /mnt/d/dev/Field-Map-Editor/src/sfml/mim_sprite.hpp:11,
                 from /mnt/d/dev/Field-Map-Editor/src/sfml/archives_group.hpp:8,
                 from /mnt/d/dev/Field-Map-Editor/src/sfml/gui/gui.hpp:6,
                 from /mnt/d/dev/Field-Map-Editor/src/sfml/test.cpp:3:
/mnt/d/dev/Field-Map-Editor/linux/build/RelWithDebInfo/_deps/openviii_cpp_wip_fetch-src/src/open_viii/graphics/Png.hpp:36:72: error: ignoring attributes on template argument ‘int (*)(FILE*)’ [-Werror=ignored-attributes]
   36 |   using safe_fp               = std::unique_ptr<FILE, decltype(&fclose)>;
      |                                                                        ^
In file included from /mnt/d/dev/Field-Map-Editor/src/sfml/filebrowser.hpp:5,
                 from /mnt/d/dev/Field-Map-Editor/src/sfml/gui/batch.hpp:11,
                 from /mnt/d/dev/Field-Map-Editor/src/sfml/gui/gui.hpp:7:
/mnt/d/dev/Field-Map-Editor/linux/build/RelWithDebInfo/_deps/imgui_filebrowser_fetch-src/imfilebrowser.h: In constructor ‘ImGui::FileBrowser::FileBrowser(ImGuiFileBrowserFlags, std::filesystem::__cxx11::path)’:
/mnt/d/dev/Field-Map-Editor/linux/build/RelWithDebInfo/_deps/imgui_filebrowser_fetch-src/imfilebrowser.h:233:8: error: conversion to ‘unsigned int’ from ‘ImGuiFileBrowserFlags’ {aka ‘int’} may change the sign of the result [-Werror=sign-conversion]
  233 |     if(flags_ & ImGuiFileBrowserFlags_CreateNewDir)
      |        ^~~~~~
/mnt/d/dev/Field-Map-Editor/linux/build/RelWithDebInfo/_deps/imgui_filebrowser_fetch-src/imfilebrowser.h: In member function ‘void ImGui::FileBrowser::Open()’:
/mnt/d/dev/Field-Map-Editor/linux/build/RelWithDebInfo/_deps/imgui_filebrowser_fetch-src/imfilebrowser.h:331:9: error: conversion to ‘unsigned int’ from ‘ImGuiFileBrowserFlags’ {aka ‘int’} may change the sign of the result [-Werror=sign-conversion]
  331 |     if((flags_ & ImGuiFileBrowserFlags_EnterNewFilename) && !customizedInputName_.empty())
      |         ^~~~~~
/mnt/d/dev/Field-Map-Editor/linux/build/RelWithDebInfo/_deps/imgui_filebrowser_fetch-src/imfilebrowser.h: In member function ‘void ImGui::FileBrowser::Display()’:
/mnt/d/dev/Field-Map-Editor/linux/build/RelWithDebInfo/_deps/imgui_filebrowser_fetch-src/imfilebrowser.h:369:24: error:
conversion to ‘unsigned int’ from ‘ImGuiFileBrowserFlags’ {aka ‘int’} may change the sign of the result [-Werror=sign-conversion]
  369 |     if(shouldOpen_ && (flags_ & ImGuiFileBrowserFlags_NoModal))
      |                        ^~~~~~
/mnt/d/dev/Field-Map-Editor/linux/build/RelWithDebInfo/_deps/imgui_filebrowser_fetch-src/imfilebrowser.h:385:8: error: conversion to ‘unsigned int’ from ‘ImGuiFileBrowserFlags’ {aka ‘int’} may change the sign of the result [-Werror=sign-conversion]
  385 |     if(flags_ & ImGuiFileBrowserFlags_NoModal)
      |        ^~~~~~
/mnt/d/dev/Field-Map-Editor/linux/build/RelWithDebInfo/_deps/imgui_filebrowser_fetch-src/imfilebrowser.h:393:30: error:
conversion to ‘unsigned int’ from ‘ImGuiFileBrowserFlags’ {aka ‘int’} may change the sign of the result [-Werror=sign-conversion]
  393 |                              flags_ & ImGuiFileBrowserFlags_NoTitleBar ? ImGuiWindowFlags_NoTitleBar : 0))
      |                              ^~~~~~
/mnt/d/dev/Field-Map-Editor/linux/build/RelWithDebInfo/_deps/imgui_filebrowser_fetch-src/imfilebrowser.h:526:12: error:
conversion to ‘unsigned int’ from ‘ImGuiFileBrowserFlags’ {aka ‘int’} may change the sign of the result [-Werror=sign-conversion]
  526 |         if(flags_ & ImGuiFileBrowserFlags_EditPathString)
      |            ^~~~~~
/mnt/d/dev/Field-Map-Editor/linux/build/RelWithDebInfo/_deps/imgui_filebrowser_fetch-src/imfilebrowser.h:562:13: error:
conversion to ‘unsigned int’ from ‘ImGuiFileBrowserFlags’ {aka ‘int’} may change the sign of the result [-Werror=sign-conversion]
  562 |         if((flags_ & ImGuiFileBrowserFlags_EnterNewFilename) && !inputNameBuffer_.empty() && inputNameBuffer_[0])
      |             ^~~~~~
/mnt/d/dev/Field-Map-Editor/linux/build/RelWithDebInfo/_deps/imgui_filebrowser_fetch-src/imfilebrowser.h:569:8: error: conversion to ‘unsigned int’ from ‘ImGuiFileBrowserFlags’ {aka ‘int’} may change the sign of the result [-Werror=sign-conversion]
  569 |     if(flags_ & ImGuiFileBrowserFlags_CreateNewDir)
      |        ^~~~~~
/mnt/d/dev/Field-Map-Editor/linux/build/RelWithDebInfo/_deps/imgui_filebrowser_fetch-src/imfilebrowser.h:606:8: error: conversion to ‘unsigned int’ from ‘ImGuiFileBrowserFlags’ {aka ‘int’} may change the sign of the result [-Werror=sign-conversion]
  606 |     if(flags_ & ImGuiFileBrowserFlags_EnterNewFilename)
      |        ^~~~~~
/mnt/d/dev/Field-Map-Editor/linux/build/RelWithDebInfo/_deps/imgui_filebrowser_fetch-src/imfilebrowser.h:613:21: error:
conversion to ‘unsigned int’ from ‘ImGuiFileBrowserFlags’ {aka ‘int’} may change the sign of the result [-Werror=sign-conversion]
  613 |                    (flags_ & ImGuiFileBrowserFlags_NoModal) ? ImGuiWindowFlags_AlwaysHorizontalScrollbar : 0);
      |                     ^~~~~~
/mnt/d/dev/Field-Map-Editor/linux/build/RelWithDebInfo/_deps/imgui_filebrowser_fetch-src/imfilebrowser.h:617:14: error:
conversion to ‘unsigned int’ from ‘ImGuiFileBrowserFlags’ {aka ‘int’} may change the sign of the result [-Werror=sign-conversion]
  617 |             (flags_ & ImGuiFileBrowserFlags_HideRegularFiles) && (flags_ & ImGuiFileBrowserFlags_SelectDirectory);
      |              ^~~~~~
/mnt/d/dev/Field-Map-Editor/linux/build/RelWithDebInfo/_deps/imgui_filebrowser_fetch-src/imfilebrowser.h:617:67: error:
conversion to ‘unsigned int’ from ‘ImGuiFileBrowserFlags’ {aka ‘int’} may change the sign of the result [-Werror=sign-conversion]
  617 |             (flags_ & ImGuiFileBrowserFlags_HideRegularFiles) && (flags_ & ImGuiFileBrowserFlags_SelectDirectory);
      |                                                                   ^~~~~~
/mnt/d/dev/Field-Map-Editor/linux/build/RelWithDebInfo/_deps/imgui_filebrowser_fetch-src/imfilebrowser.h:638:38: error:
conversion to ‘unsigned int’ from ‘ImGuiFileBrowserFlags’ {aka ‘int’} may change the sign of the result [-Werror=sign-conversion]
  638 |                 const bool wantDir = flags_ & ImGuiFileBrowserFlags_SelectDirectory;
      |                                      ^~~~~~
/mnt/d/dev/Field-Map-Editor/linux/build/RelWithDebInfo/_deps/imgui_filebrowser_fetch-src/imfilebrowser.h:643:22: error:
conversion to ‘unsigned int’ from ‘ImGuiFileBrowserFlags’ {aka ‘int’} may change the sign of the result [-Werror=sign-conversion]
  643 |                     (flags_ & ImGuiFileBrowserFlags_MultipleSelection) &&
      |                      ^~~~~~
/mnt/d/dev/Field-Map-Editor/linux/build/RelWithDebInfo/_deps/imgui_filebrowser_fetch-src/imfilebrowser.h:647:22: error:
conversion to ‘unsigned int’ from ‘ImGuiFileBrowserFlags’ {aka ‘int’} may change the sign of the result [-Werror=sign-conversion]
  647 |                     (flags_ & ImGuiFileBrowserFlags_MultipleSelection) &&
      |                      ^~~~~~
/mnt/d/dev/Field-Map-Editor/linux/build/RelWithDebInfo/_deps/imgui_filebrowser_fetch-src/imfilebrowser.h:679:24: error:
conversion to ‘unsigned int’ from ‘ImGuiFileBrowserFlags’ {aka ‘int’} may change the sign of the result [-Werror=sign-conversion]
  679 |                     if(flags_ & ImGuiFileBrowserFlags_EnterNewFilename)
      |                        ^~~~~~
/mnt/d/dev/Field-Map-Editor/linux/build/RelWithDebInfo/_deps/imgui_filebrowser_fetch-src/imfilebrowser.h:694:24: error:
conversion to ‘unsigned int’ from ‘ImGuiFileBrowserFlags’ {aka ‘int’} may change the sign of the result [-Werror=sign-conversion]
  694 |                     if(flags_ & ImGuiFileBrowserFlags_EnterNewFilename)
      |                        ^~~~~~
/mnt/d/dev/Field-Map-Editor/linux/build/RelWithDebInfo/_deps/imgui_filebrowser_fetch-src/imfilebrowser.h:710:27: error:
conversion to ‘unsigned int’ from ‘ImGuiFileBrowserFlags’ {aka ‘int’} may change the sign of the result [-Werror=sign-conversion]
  710 |                 else if(!(flags_ & ImGuiFileBrowserFlags_SelectDirectory))
      |                           ^~~~~~
/mnt/d/dev/Field-Map-Editor/linux/build/RelWithDebInfo/_deps/imgui_filebrowser_fetch-src/imfilebrowser.h:725:27: error:
conversion to ‘unsigned int’ from ‘ImGuiFileBrowserFlags’ {aka ‘int’} may change the sign of the result [-Werror=sign-conversion]
  725 |                 else if(!(flags_ & ImGuiFileBrowserFlags_SelectDirectory))
      |                           ^~~~~~
/mnt/d/dev/Field-Map-Editor/linux/build/RelWithDebInfo/_deps/imgui_filebrowser_fetch-src/imfilebrowser.h:740:8: error: conversion to ‘unsigned int’ from ‘ImGuiFileBrowserFlags’ {aka ‘int’} may change the sign of the result [-Werror=sign-conversion]
  740 |     if(flags_ & ImGuiFileBrowserFlags_EnterNewFilename)
      |        ^~~~~~
/mnt/d/dev/Field-Map-Editor/linux/build/RelWithDebInfo/_deps/imgui_filebrowser_fetch-src/imfilebrowser.h:763:33: error:
conversion to ‘unsigned int’ from ‘ImGuiFileBrowserFlags’ {aka ‘int’} may change the sign of the result [-Werror=sign-conversion]
  763 |         const bool selectAll = (flags_ & ImGuiFileBrowserFlags_MultipleSelection) &&
      |                                 ^~~~~~
/mnt/d/dev/Field-Map-Editor/linux/build/RelWithDebInfo/_deps/imgui_filebrowser_fetch-src/imfilebrowser.h:768:34: error:
conversion to ‘unsigned int’ from ‘ImGuiFileBrowserFlags’ {aka ‘int’} may change the sign of the result [-Werror=sign-conversion]
  768 |             const bool needDir = flags_ & ImGuiFileBrowserFlags_SelectDirectory;
      |                                  ^~~~~~
/mnt/d/dev/Field-Map-Editor/linux/build/RelWithDebInfo/_deps/imgui_filebrowser_fetch-src/imfilebrowser.h:783:10: error:
conversion to ‘unsigned int’ from ‘ImGuiFileBrowserFlags’ {aka ‘int’} may change the sign of the result [-Werror=sign-conversion]
  783 |         (flags_ & ImGuiFileBrowserFlags_ConfirmOnEnter) &&
      |          ^~~~~~
/mnt/d/dev/Field-Map-Editor/linux/build/RelWithDebInfo/_deps/imgui_filebrowser_fetch-src/imfilebrowser.h:786:10: error:
conversion to ‘unsigned int’ from ‘ImGuiFileBrowserFlags’ {aka ‘int’} may change the sign of the result [-Werror=sign-conversion]
  786 |     if(!(flags_ & ImGuiFileBrowserFlags_SelectDirectory))
      |          ^~~~~~
/mnt/d/dev/Field-Map-Editor/linux/build/RelWithDebInfo/_deps/imgui_filebrowser_fetch-src/imfilebrowser.h:807:11: error:
conversion to ‘unsigned int’ from ‘ImGuiFileBrowserFlags’ {aka ‘int’} may change the sign of the result [-Werror=sign-conversion]
  807 |         ((flags_ & ImGuiFileBrowserFlags_CloseOnEsc) &&
      |           ^~~~~~
/mnt/d/dev/Field-Map-Editor/linux/build/RelWithDebInfo/_deps/imgui_filebrowser_fetch-src/imfilebrowser.h:815:33: error:
conversion to ‘unsigned int’ from ‘ImGuiFileBrowserFlags’ {aka ‘int’} may change the sign of the result [-Werror=sign-conversion]
  815 |     if(!statusStr_.empty() && !(flags_ & ImGuiFileBrowserFlags_NoStatusBar))
      |                                 ^~~~~~
/mnt/d/dev/Field-Map-Editor/linux/build/RelWithDebInfo/_deps/imgui_filebrowser_fetch-src/imfilebrowser.h: In member function ‘void ImGui::FileBrowser::ClearSelected()’:
/mnt/d/dev/Field-Map-Editor/linux/build/RelWithDebInfo/_deps/imgui_filebrowser_fetch-src/imfilebrowser.h:890:9: error: conversion to ‘unsigned int’ from ‘ImGuiFileBrowserFlags’ {aka ‘int’} may change the sign of the result [-Werror=sign-conversion]
  890 |     if((flags_ & ImGuiFileBrowserFlags_EnterNewFilename))
      |         ^~~~~~
/mnt/d/dev/Field-Map-Editor/linux/build/RelWithDebInfo/_deps/imgui_filebrowser_fetch-src/imfilebrowser.h: In member function ‘void ImGui::FileBrowser::UpdateFileRecords()’:
/mnt/d/dev/Field-Map-Editor/linux/build/RelWithDebInfo/_deps/imgui_filebrowser_fetch-src/imfilebrowser.h:1008:18: error: conversion to ‘unsigned int’ from ‘ImGuiFileBrowserFlags’ {aka ‘int’} may change the sign of the result [-Werror=sign-conversion]
 1008 |             if(!(flags_ & ImGuiFileBrowserFlags_SkipItemsCausingError))
      |                  ^~~~~~
/mnt/d/dev/Field-Map-Editor/linux/build/RelWithDebInfo/_deps/imgui_filebrowser_fetch-src/imfilebrowser.h: In member function ‘void ImGui::FileBrowser::SetCurrentDirectoryUncatched(const std::filesystem::__cxx11::path&)’:
/mnt/d/dev/Field-Map-Editor/linux/build/RelWithDebInfo/_deps/imgui_filebrowser_fetch-src/imfilebrowser.h:1076:9: error:
conversion to ‘unsigned int’ from ‘ImGuiFileBrowserFlags’ {aka ‘int’} may change the sign of the result [-Werror=sign-conversion]
 1076 |     if((flags_ & ImGuiFileBrowserFlags_EnterNewFilename) &&
      |         ^~~~~~
/mnt/d/dev/Field-Map-Editor/linux/build/RelWithDebInfo/_deps/imgui_filebrowser_fetch-src/imfilebrowser.h: In member function ‘void ImGui::FileBrowser::ClearRangeSelectionState()’:
/mnt/d/dev/Field-Map-Editor/linux/build/RelWithDebInfo/_deps/imgui_filebrowser_fetch-src/imfilebrowser.h:1174:22: error: conversion to ‘unsigned int’ from ‘ImGuiFileBrowserFlags’ {aka ‘int’} may change the sign of the result [-Werror=sign-conversion]
 1174 |     const bool dir = flags_ & ImGuiFileBrowserFlags_SelectDirectory;
      |                      ^~~~~~
cc1plus: all warnings being treated as errors
make[2]: *** [src/sfml/CMakeFiles/Field-Map-Editor_SFML.dir/build.make:76: src/sfml/CMakeFiles/Field-Map-Editor_SFML.dir/test.cpp.o] Error 1
make[1]: *** [CMakeFiles/Makefile2:595: src/sfml/CMakeFiles/Field-Map-Editor_SFML.dir/all] Error 2
make: *** [Makefile:91: all] Error 2
(venv) root@DESKTOP-PO4DJP8:/mnt/d/dev/Field-Map-Editor/linux/build/relwithdebinfo#
```

</details



After fixing the type to uint32_t, users might see errors/warnings like below where they were already fixing the type via a cast they can just remove the casts.
<details><summary>More Logs</summary>


```c++
In file included from /mnt/d/dev/Field-Map-Editor/src/sfml/mim_sprite.hpp:11,
                 from /mnt/d/dev/Field-Map-Editor/src/sfml/archives_group.hpp:8,
                 from /mnt/d/dev/Field-Map-Editor/src/sfml/gui/gui.hpp:6,
                 from /mnt/d/dev/Field-Map-Editor/src/sfml/test.cpp:3:
/mnt/d/dev/Field-Map-Editor/linux/build/RelWithDebInfo/_deps/openviii_cpp_wip_fetch-src/src/open_viii/graphics/Png.hpp:36:72: error: ignoring attributes on template argument ‘int (*)(FILE*)’ [-Werror=ignored-attributes]
   36 |   using safe_fp               = std::unique_ptr<FILE, decltype(&fclose)>;
      |                                                                        ^
In file included from /mnt/d/dev/Field-Map-Editor/src/sfml/gui/gui.hpp:7:
/mnt/d/dev/Field-Map-Editor/src/sfml/gui/batch.hpp:52:95: error: useless cast to type ‘using ImGuiFileBrowserFlags = uint32_t’ {aka ‘unsigned int’} [-Werror=useless-cast]
   52 |      ImGui::FileBrowser                                                  m_directory_browser{ static_cast<ImGuiFileBrowserFlags>(
      |                                                                                               ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
   53 |        static_cast<std::uint32_t>(ImGuiFileBrowserFlags_SelectDirectory)
      |        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
   54 |        | static_cast<std::uint32_t>(ImGuiFileBrowserFlags_CreateNewDir)) };
      |        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/mnt/d/dev/Field-Map-Editor/src/sfml/gui/gui.hpp:83:95: error: useless cast to type ‘using ImGuiFileBrowserFlags = uint32_t’ {aka ‘unsigned int’} [-Werror=useless-cast]
   83 |      ImGui::FileBrowser                                                  m_save_file_browser{ static_cast<ImGuiFileBrowserFlags>(
      |                                                                                               ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
   84 |        static_cast<std::uint32_t>(ImGuiFileBrowserFlags_EnterNewFilename)
      |        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
   85 |        | static_cast<std::uint32_t>(ImGuiFileBrowserFlags_CreateNewDir)) };
      |        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/mnt/d/dev/Field-Map-Editor/src/sfml/gui/gui.hpp:87:95: error: useless cast to type ‘using ImGuiFileBrowserFlags = uint32_t’ {aka ‘unsigned int’} [-Werror=useless-cast]
   87 |      ImGui::FileBrowser                                                  m_directory_browser{ static_cast<ImGuiFileBrowserFlags>(
      |                                                                                               ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
   88 |        static_cast<std::uint32_t>(ImGuiFileBrowserFlags_SelectDirectory)
      |        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
   89 |        | static_cast<std::uint32_t>(ImGuiFileBrowserFlags_CreateNewDir)) };
      |        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
cc1plus: all warnings being treated as errors
make[2]: *** [src/sfml/CMakeFiles/Field-Map-Editor_SFML.dir/build.make:76: src/sfml/CMakeFiles/Field-Map-Editor_SFML.dir/test.cpp.o] Error 1
make[1]: *** [CMakeFiles/Makefile2:595: src/sfml/CMakeFiles/Field-Map-Editor_SFML.dir/all] Error 2
make: *** [Makefile:91: all] Error 2
(venv) root@DESKTOP-PO4DJP8:/mnt/d/dev/Field-Map-Editor/linux/build/RelWithDebInfo#

then i guess i had still more casts to remove

In file included from /mnt/d/dev/Field-Map-Editor/src/sfml/gui/gui.hpp:7:
/mnt/d/dev/Field-Map-Editor/src/sfml/gui/batch.hpp:52:95: error: useless cast to type ‘using ImGuiFileBrowserFlags = uint32_t’ {aka ‘unsigned int’} [-Werror=useless-cast]
   52 |      ImGui::FileBrowser                                                  m_directory_browser{ static_cast<ImGuiFileBrowserFlags>(
      |                                                                                               ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
   53 |        ImGuiFileBrowserFlags_SelectDirectory | ImGuiFileBrowserFlags_CreateNewDir) };
      |        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/mnt/d/dev/Field-Map-Editor/src/sfml/gui/gui.hpp:83:95: error: useless cast to type ‘using ImGuiFileBrowserFlags = uint32_t’ {aka ‘unsigned int’} [-Werror=useless-cast]
   83 |      ImGui::FileBrowser                                                  m_save_file_browser{ static_cast<ImGuiFileBrowserFlags>(
      |                                                                                               ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
   84 |        ImGuiFileBrowserFlags_EnterNewFilename | ImGuiFileBrowserFlags_CreateNewDir) };
      |        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/mnt/d/dev/Field-Map-Editor/src/sfml/gui/gui.hpp:86:95: error: useless cast to type ‘using ImGuiFileBrowserFlags = uint32_t’ {aka ‘unsigned int’} [-Werror=useless-cast]
   86 |      ImGui::FileBrowser                                                  m_directory_browser{ static_cast<ImGuiFileBrowserFlags>(
      |                                                                                               ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
   87 |        ImGuiFileBrowserFlags_SelectDirectory | ImGuiFileBrowserFlags_CreateNewDir) };
      |        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```

</details>