### PR TITLE
Fixed error due to using deprecated enum.

### DIFF
--- a/imfilebrowser.h
+++ b/imfilebrowser.h
@@ -633,7 +633,7 @@ inline void ImGui::FileBrowser::Display()
             }
 
             const bool selected = selectedFilenames_.find(rsc.name) != selectedFilenames_.end();
-            if(Selectable(rsc.showName.c_str(), selected, ImGuiSelectableFlags_DontClosePopups))
+            if(Selectable(rsc.showName.c_str(), selected, ImGuiSelectableFlags_NoAutoClosePopups))
             {
                 const bool wantDir = flags_ & ImGuiFileBrowserFlags_SelectDirectory;
                 const bool canSelect = rsc.name != ".." && rsc.isDir == wantDir;

--- a/imfilebrowser.h
+++ b/imfilebrowser.h
@@ -633,7 +633,14 @@ inline void ImGui::FileBrowser::Display()
             }
 
             const bool selected = selectedFilenames_.find(rsc.name) != selectedFilenames_.end();
-            if(Selectable(rsc.showName.c_str(), selected, ImGuiSelectableFlags_NoAutoClosePopups))
+            
+#if IMGUI_VERSION_NUM >= 19100
+            const ImGuiSelectableFlags selectableFlag = ImGuiSelectableFlags_NoAutoClosePopups;
+#else
+            const ImGuiSelectableFlags selectableFlag = ImGuiSelectableFlags_DontClosePopups;
+#endif
+
+            if(Selectable(rsc.showName.c_str(), selected, selectableFlag))
             {
                 const bool wantDir = flags_ & ImGuiFileBrowserFlags_SelectDirectory;
                 const bool canSelect = rsc.name != ".." && rsc.isDir == wantDir;


### PR DESCRIPTION
Hi!

`ImGuiSelectableFlags_DontClosePopups` was deprecated on ImGui 1.91, and if `IMGUI_DISABLE_OBSOLETE_FUNCTIONS` is defined, it will not compile. It was renamed to `ImGuiSelectableFlags_NoAutoClosePopups`.