### PR TITLE
Slightly larger buffer when creating a new directory

### DIFF
--- a/imfilebrowser.h
+++ b/imfilebrowser.h
@@ -234,7 +234,7 @@ inline ImGui::FileBrowser::FileBrowser(ImGuiFileBrowserFlags flags, std::filesys
            "'EnterNewFilename' doesn't work when 'SelectDirectory' is enabled");
     if(flags_ & ImGuiFileBrowserFlags_CreateNewDir)
     {
-        newDirNameBuffer_.resize(8, '\0');
+        newDirNameBuffer_.resize(32, '\0');
     }
 
     SetTitle("file browser");


### PR DESCRIPTION
Exactly like the commit title says :)
A buffer size of 8 is just too small (in my case, it's not enough even for an 'examples' folder, there is only room for 'example' + \0). 