### PR TITLE
`directory_iterator` throws.

### DIFF
--- a/imfilebrowser.h
+++ b/imfilebrowser.h
@@ -851,6 +851,10 @@ inline void ImGui::FileBrowser::Display()
     {
         SameLine();
         Text("%s", statusStr_.c_str());
+        if (!statusStr_.empty() && ImGui::IsItemHovered())
+        {
+            ImGui::SetTooltip("%s", statusStr_.c_str());
+        }
     }
 
     if(!typeFilters_.empty())

--- a/imfilebrowser.h
+++ b/imfilebrowser.h
@@ -853,8 +853,10 @@ inline void ImGui::FileBrowser::Display()
         Text("%s", statusStr_.c_str());
         if (ImGui::IsItemHovered())
         {
-            ImGui::BeginTooltip();
-            ImGui::TextWrapped("%s", statusStr_.c_str());
+            ImGui::BeginTooltip();            
+            ImGui::PushTextWrapPos(200.0f); // wrap at 200 pixels
+            ImGui::Text("%s", statusStr_.c_str());
+            ImGui::PopTextWrapPos();
             ImGui::EndTooltip();
         }
     }

--- a/imfilebrowser.h
+++ b/imfilebrowser.h
@@ -854,7 +854,7 @@ inline void ImGui::FileBrowser::Display()
         if (ImGui::IsItemHovered())
         {
             ImGui::BeginTooltip();            
-            ImGui::PushTextWrapPos(200.0f); // wrap at 200 pixels
+            ImGui::PushTextWrapPos(300.0f);
             ImGui::Text("%s", statusStr_.c_str());
             ImGui::PopTextWrapPos();
             ImGui::EndTooltip();

--- a/imfilebrowser.h
+++ b/imfilebrowser.h
@@ -851,7 +851,7 @@ inline void ImGui::FileBrowser::Display()
     {
         SameLine();
         Text("%s", statusStr_.c_str());
-        if (!statusStr_.empty() && ImGui::IsItemHovered())
+        if (ImGui::IsItemHovered())
         {
             ImGui::SetTooltip("%s", statusStr_.c_str());
         }

--- a/imfilebrowser.h
+++ b/imfilebrowser.h
@@ -1020,7 +1020,23 @@ inline void ImGui::FileBrowser::UpdateFileRecords()
 {
     fileRecords_ = { FileRecord{ true, "..", "[D] ..", "" } };
 
-    for(auto &p : std::filesystem::directory_iterator(currentDirectory_))
+    const auto get_directory_iterator = [&]() -> std::filesystem::directory_iterator
+    {
+        try
+        {
+            return std::filesystem::directory_iterator(currentDirectory_);
+        }
+        catch (const std::filesystem::filesystem_error&)
+        {
+            if (!(flags_ & ImGuiFileBrowserFlags_SkipItemsCausingError))
+            {
+                throw;
+            }
+            return {};
+        }
+    };
+
+    for(auto &p : get_directory_iterator())
     {
         FileRecord rcd;
         try

--- a/imfilebrowser.h
+++ b/imfilebrowser.h
@@ -1028,7 +1028,7 @@ inline void ImGui::FileBrowser::UpdateFileRecords()
 {
     fileRecords_ = { FileRecord{ true, "..", "[D] ..", "" } };
 
-    const auto get_directory_iterator = [&]() -> std::filesystem::directory_iterator
+    const auto getDirectoryIterator = [&]() -> std::filesystem::directory_iterator
     {
         try
         {            
@@ -1045,7 +1045,7 @@ inline void ImGui::FileBrowser::UpdateFileRecords()
         }
     };
 
-    for(auto &p : get_directory_iterator())
+    for(auto &p : getDirectoryIterator())
     {
         FileRecord rcd;
         try

--- a/imfilebrowser.h
+++ b/imfilebrowser.h
@@ -1023,11 +1023,12 @@ inline void ImGui::FileBrowser::UpdateFileRecords()
     const auto get_directory_iterator = [&]() -> std::filesystem::directory_iterator
     {
         try
-        {
+        {            
             return std::filesystem::directory_iterator(currentDirectory_);
         }
-        catch (const std::filesystem::filesystem_error&)
-        {
+        catch (const std::filesystem::filesystem_error& err)
+        {            
+            statusStr_ = std::string("error: ") + err.what();
             if (!(flags_ & ImGuiFileBrowserFlags_SkipItemsCausingError))
             {
                 throw;

--- a/imfilebrowser.h
+++ b/imfilebrowser.h
@@ -853,7 +853,9 @@ inline void ImGui::FileBrowser::Display()
         Text("%s", statusStr_.c_str());
         if (ImGui::IsItemHovered())
         {
-            ImGui::SetTooltip("%s", statusStr_.c_str());
+            ImGui::BeginTooltip();
+            ImGui::TextWrapped("%s", statusStr_.c_str());
+            ImGui::EndTooltip();
         }
     }
 


### PR DESCRIPTION
fixes: https://github.com/AirGuanZ/imgui-filebrowser/issues/73
fixes: https://github.com/Sebanisu/Field-Map-Editor/issues/169

<img width="1454" height="496" alt="image" src="https://github.com/user-attachments/assets/244f2e2c-5315-4517-962b-17276dc7bf52" />

I noticed if you selected a path in the browser. Made the path not exist. Then reopen the browser it would throw. So I added a lambda wrapper around the call that does a try/catch. The catch sets statusStr_ and uses the ImGuiFileBrowserFlags_SkipItemsCausingError to see if we should rethrow or not.

I hope this will be acceptable.

I also added a tooltip to statusStr_ because it was getting cut off. I added text wrapping to the tooltip because it was so long.
```c++
ImGui::BeginTooltip();            
ImGui::PushTextWrapPos(300.0f);
ImGui::Text("%s", statusStr_.c_str());
ImGui::PopTextWrapPos();
ImGui::EndTooltip();
```